### PR TITLE
With SSL replication, disable hostname checking

### DIFF
--- a/spec/defines/replication_spec.rb
+++ b/spec/defines/replication_spec.rb
@@ -237,6 +237,11 @@ nsDS5ReplicaBindMethod: SIMPLE
 nsDS5ReplicaCredentials: supersecret
 nsDS5ReplicaRoot: dc=test,dc=org
 description: replication agreement from specdirectory to consumer1
+
+dn: cn=config
+changetype: modify
+replace: nsslapd-ssl-check-hostname
+nsslapd-ssl-check-hostname: off
 '
   end
 
@@ -271,6 +276,11 @@ nsDS5ReplicaBindMethod: SIMPLE
 nsDS5ReplicaCredentials: supersecret
 nsDS5ReplicaRoot: dc=test,dc=org
 description: replication agreement from specdirectory to hub1
+
+dn: cn=config
+changetype: modify
+replace: nsslapd-ssl-check-hostname
+nsslapd-ssl-check-hostname: off
 '
   end
 
@@ -305,6 +315,11 @@ nsDS5ReplicaBindMethod: SIMPLE
 nsDS5ReplicaCredentials: supersecret
 nsDS5ReplicaRoot: dc=test,dc=org
 description: replication agreement from specdirectory to supplier1
+
+dn: cn=config
+changetype: modify
+replace: nsslapd-ssl-check-hostname
+nsslapd-ssl-check-hostname: off
 '
   end
 

--- a/templates/replication_agreement.erb
+++ b/templates/replication_agreement.erb
@@ -14,3 +14,10 @@ description: replication agreement from <%= @name %> to <%= @replica %>
 <%- if @attribute_list -%>
 nsDS5ReplicatedAttributeList: (objectclass=*) $ EXCLUDE <%= @attribute_list %>
 <%- end -%>
+
+<%- if @replica_transport == 'SSL' -%>
+dn: cn=config
+changetype: modify
+replace: nsslapd-ssl-check-hostname
+nsslapd-ssl-check-hostname: off
+<%- end -%>

--- a/templates/replication_agreement.erb
+++ b/templates/replication_agreement.erb
@@ -14,8 +14,8 @@ description: replication agreement from <%= @name %> to <%= @replica %>
 <%- if @attribute_list -%>
 nsDS5ReplicatedAttributeList: (objectclass=*) $ EXCLUDE <%= @attribute_list %>
 <%- end -%>
-
 <%- if @replica_transport == 'SSL' -%>
+
 dn: cn=config
 changetype: modify
 replace: nsslapd-ssl-check-hostname


### PR DESCRIPTION
If the SSL transport is used for replication, disable SSL client hostname checking. 

Some background. Setting nsslapd-ssl-check-hostname to off changes the LDAP client from using LDAPSSL_AUTH_CNCHECK to LDAPSSL_AUTH_CERT ( documentation: 
https://wiki.mozilla.org/Mozilla_LDAP_SDK_Programmer%27s_Guide/LDAP_C_SDK_Function_Reference#ldapssl_set_strength.28.29 ).

In my environment, I am using an SSL certificate and Intermediate chain from Digicert ( ie. not self-signed ), the cert is trusted by standard LDAP clients but is not trusted by the built-in client that is making the replication connection to the consumer.   I'm using a wildcard certificate, I would imagine the build-in LDAP client is just comparing the consumer hostname with the cert name ( which won't match a wildcard cert, but *that's okay*).