### PR TITLE
Ensure output cert bundle has line breaks between elements - fixes #20

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -105,9 +105,10 @@ define ds_389::instance(
       order  => '2',
     }
     concat { "${server_id}_cert_bundle":
-      mode   => '0600',
-      path   => "${::ds_389::params::ssl_dir}/${server_id}-bundle.pem",
-      notify => Exec["Create pkcs12 cert: ${server_id}"],
+      mode           => '0600',
+      path           => "${::ds_389::params::ssl_dir}/${server_id}-bundle.pem",
+      ensure_newline => true,
+      notify         => Exec["Create pkcs12 cert: ${server_id}"],
     }
 
     # create pkcs12 cert


### PR DESCRIPTION
As per issue #20 , if you supply your cert bundle elements via eyaml it is possible the resulting output can be invalid due to missing line breaks. 