### PR TITLE
Add support for Ubuntu 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: bundler
 before_install:
   - bundle -v
   - rm Gemfile.lock || true
-  - gem update --system
+  - gem install "rubygems-update:<3.0.0" --no-document
   - gem update bundler
   - gem --version
   - bundle -v

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ The following defines are typically called from an instance.
 
 ## Limitations
 
-This module is currently tested and working on RedHat and CentOS 6, and 7, Debian 8, and 9, Ubuntu 14.04, and 16.04 systems.
+This module is currently tested and working on RedHat and CentOS 6, and 7, Debian 8, and 9, Ubuntu 14.04, 16.04, and 18.04 systems.
 
 ## Development
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class ds_389::params {
       $cacert_rehash = 'c_rehash'
       $limits_config_dir = '/etc/default'
       case $::operatingsystemmajrelease {
-        '8', '9', '16.04': {
+        '8', '9', '16.04', '18.04': {
           $service_type = 'systemd'
           $ssl_version_min_support = true
         }

--- a/metadata.json
+++ b/metadata.json
@@ -46,6 +46,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
+        "18.04",
         "16.04",
         "14.04"
       ]

--- a/spec/classes/ds389_spec.rb
+++ b/spec/classes/ds389_spec.rb
@@ -56,7 +56,7 @@ describe 'ds_389' do
           }
 
           case os_facts[:operatingsystemmajrelease]
-          when '8', '9', '16.04'
+          when '8', '9', '16.04', '18.04'
             it {
               is_expected.to contain_ini_setting('dirsrv ulimit').with(
                 ensure: 'present',

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -59,7 +59,7 @@ describe 'ds_389::instance' do
           }
 
           case os_facts[:operatingsystemmajrelease]
-          when '8', '9', '16.04'
+          when '8', '9', '16.04', '18.04'
             it {
               is_expected.to contain_exec('stop specdirectory to create new token').with(
                 command: '/bin/systemctl stop dirsrv@specdirectory ; sleep 2',
@@ -758,7 +758,7 @@ describe 'ds_389::instance' do
           }
 
           case os_facts[:operatingsystemmajrelease]
-          when '8', '9', '16.04'
+          when '8', '9', '16.04', '18.04'
             it {
               is_expected.to contain_exec('stop ldap01 to create new token').with(
                 command: '/bin/systemctl stop dirsrv@ldap01 ; sleep 2',

--- a/spec/defines/service_spec.rb
+++ b/spec/defines/service_spec.rb
@@ -86,7 +86,7 @@ exit 0
         case os_facts[:osfamily]
         when 'Debian'
           case os_facts[:operatingsystemmajrelease]
-          when '8', '9', '16.04'
+          when '8', '9', '16.04', '18.04'
             it {
               is_expected.to contain_service('dirsrv@specdirectory').with(
                 ensure: 'running',
@@ -161,7 +161,7 @@ exit 0
         case os_facts[:osfamily]
         when 'Debian'
           case os_facts[:operatingsystemmajrelease]
-          when '8', '9', '16.04'
+          when '8', '9', '16.04', '18.04'
             it {
               is_expected.to contain_service('dirsrv@ldap01').with(
                 ensure: 'stopped',

--- a/spec/defines/ssl_spec.rb
+++ b/spec/defines/ssl_spec.rb
@@ -178,7 +178,7 @@ nsslapd-securePort: 1636
         case os_facts[:osfamily]
         when 'Debian'
           case os_facts[:operatingsystemmajrelease]
-          when '8', '9', '16.04'
+          when '8', '9', '16.04', '18.04'
             it {
               is_expected.to contain_file('/etc/dirsrv/slapd-specdirectory/ssl.ldif').with(
                 ensure: 'file',
@@ -290,7 +290,7 @@ nsslapd-securePort: 1636
         case os_facts[:osfamily]
         when 'Debian'
           case os_facts[:operatingsystemmajrelease]
-          when '8', '9', '16.04'
+          when '8', '9', '16.04', '18.04'
             it {
               is_expected.to contain_file('/etc/dirsrv/slapd-ldap01/ssl.ldif').with(
                 ensure: 'file',


### PR DESCRIPTION
This adds support for Ubuntu 18.04.

I had to modify the Travis-CI setup in order to get tests to run on Ruby 2.1.9 as well.