### PR TITLE
add support for CentOS 8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,15 +14,19 @@
 # @param cacerts_path Target directory the 389 ds certs should be exported to. Default: '/etc/openldap/cacerts'
 # @param home_dir Home directory for the 389 ds user account. Default: '/usr/share/dirsrv'
 # @param instances A hash of ds_389::instance resources. Optional.
+# @param dnf_module_name The name of the DNF module that should be enabled on RHEL. Optional.
+# @param dnf_module_version The version of the DNF module that should be enabled on RHEL. Optional.
 #
 class ds_389 (
-  String               $package_name   = '389-ds-base',
+  Variant[String,Array] $package_name  = $::ds_389::params::package_name,
   String               $package_ensure = 'installed',
   String               $user           = 'dirsrv',
   String               $group          = 'dirsrv',
   Stdlib::Absolutepath $cacerts_path   = '/etc/openldap/cacerts',
   Stdlib::Absolutepath $home_dir       = '/usr/share/dirsrv',
   Optional[Hash]       $instances      = undef,
+  Optional[String]     $dnf_module_name = $::ds_389::params::dnf_module_name,
+  Optional[String]     $dnf_module_version = $::ds_389::params::dnf_module_version,
 ) inherits ds_389::params {
 
   class { '::ds_389::install': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,9 @@ class ds_389::params {
       $setup_ds = 'setup-ds'
       $cacert_rehash = 'c_rehash'
       $limits_config_dir = '/etc/default'
+      $package_name = '389-ds-base'
+      $dnf_module_name = undef
+      $dnf_module_version = undef
       case $::operatingsystemmajrelease {
         '8', '9', '16.04': {
           $service_type = 'systemd'
@@ -28,16 +31,31 @@ class ds_389::params {
       $user_shell = '/sbin/nologin'
       $nsstools_package_name = 'nss-tools'
       $setup_ds = 'setup-ds.pl'
-      $cacert_rehash = 'cacertdir_rehash'
       $limits_config_dir = '/etc/sysconfig'
       case $::operatingsystemmajrelease {
         '7': {
           $service_type = 'systemd'
           $ssl_version_min_support = true
+          $cacert_rehash = 'cacertdir_rehash'
+          $package_name = '389-ds-base'
+          $dnf_module_name = undef
+          $dnf_module_version = undef
+        }
+        '8': {
+          $service_type = 'systemd'
+          $ssl_version_min_support = true
+          $cacert_rehash = 'openssl rehash'
+          $package_name = ['389-ds-base','389-ds-base-legacy-tools']
+          $dnf_module_name = '389-ds'
+          $dnf_module_version = '1.4'
         }
         default: {
           $service_type = 'init'
           $ssl_version_min_support = false
+          $cacert_rehash = 'cacertdir_rehash'
+          $package_name = '389-ds-base'
+          $dnf_module_name = undef
+          $dnf_module_version = undef
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
+        "8",
         "7",
         "6"
       ]
@@ -32,6 +33,7 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
+        "8",
         "7",
         "6"
       ]


### PR DESCRIPTION
A few things are required for RHEL/CentOS 8 support:

* enable the DNF module for 389-ds (otherwise the packages cannot be installed)
* install legacy tools package (otherwise the module would have to use the new dsconf tool)
* change `$package_name` to allow specifying more than one package (backwards compatible)
